### PR TITLE
Remove polyfills

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "example:build": "npx webpack --context example --config example/webpack.config.js"
   },
   "dependencies": {
-    "@babel/polyfill": "^7.0.0-beta.47",
     "camelcase": "^5.0.0",
     "debug": "^3.1.0",
     "lodash": "^4.17.10",

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-import '@babel/polyfill';
 import path from 'path';
 import _ from 'lodash';
 import camelcase from 'camelcase';

--- a/yarn.lock
+++ b/yarn.lock
@@ -443,13 +443,6 @@
     "@babel/helper-regex" "7.0.0-beta.47"
     regexpu-core "^4.1.3"
 
-"@babel/polyfill@^7.0.0-beta.47":
-  version "7.0.0-beta.47"
-  resolved "https://registry.yarnpkg.com/@babel/polyfill/-/polyfill-7.0.0-beta.47.tgz#2ef0a6ee02a23a0ab98fc4eb6aed7e88560bc35d"
-  dependencies:
-    core-js "^2.5.3"
-    regenerator-runtime "^0.11.1"
-
 "@babel/preset-env@^7.0.0-beta.47":
   version "7.0.0-beta.47"
   resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.0.0-beta.47.tgz#a3dab3b5fac4de56e3510bdbcb528f1cbdedbe2d"
@@ -2327,7 +2320,7 @@ core-js@^1.0.0:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
 
-core-js@^2.4.0, core-js@^2.4.1, core-js@^2.5.0, core-js@^2.5.3:
+core-js@^2.4.0, core-js@^2.4.1, core-js@^2.5.0:
   version "2.5.6"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.6.tgz#0fe6d45bf3cac3ac364a9d72de7576f4eb221b9d"
 
@@ -6821,7 +6814,7 @@ regenerate@^1.2.1, regenerate@^1.3.3, regenerate@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.0.tgz#4a856ec4b56e4077c557589cae85e7a4c8869a11"
 
-regenerator-runtime@^0.11.0, regenerator-runtime@^0.11.1:
+regenerator-runtime@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
 


### PR DESCRIPTION
When I install plugin and start webpack, it throws an error: `Error: Cannot find module 'core-js/modules/es6.array.sort'`.

The package has no dependencies for this and other polyfills. Meanwhile webpack works on the nodejs and it seems that polyfills not required at all.